### PR TITLE
强制禁用VAMAP,并且修正传递给内核的PAYLOAD CONFIG Table的值

### DIFF
--- a/apps/elf.c
+++ b/apps/elf.c
@@ -468,8 +468,8 @@ efi_status_t load_elf(struct payload_info *payload_info)
 		return status;
 	}
 
-	tbl->payload_addr = payload_info->payload_addr;
-	tbl->payload_size = payload_info->payload_size;
+	tbl->loaded_addr = payload_info->loaded_paddr;
+	tbl->size = payload_info->loaded_size;
 
 	efi_guid_t dragonstub_payload_efi_guid =
 		DRAGONSTUB_EFI_PAYLOAD_EFI_GUID;

--- a/apps/fdt.c
+++ b/apps/fdt.c
@@ -306,7 +306,6 @@ static efi_status_t allocate_new_fdt_and_exit_boot(void *handle,
 		svam = ST->RuntimeServices->SetVirtualAddressMap;
 		status = svam(priv.runtime_entry_count * desc_size, desc_size,
 			      desc_ver, priv.runtime_map);
-
 		/*
 			 * We are beyond the point of no return here, so if the call to
 			 * SetVirtualAddressMap() failed, we need to signal that to the

--- a/apps/helper.c
+++ b/apps/helper.c
@@ -8,7 +8,7 @@
 bool efi_nochunk;
 bool efi_nokaslr = true;
 // bool efi_nokaslr = !IS_ENABLED(CONFIG_RANDOMIZE_BASE);
-bool efi_novamap = false;
+bool efi_novamap = true;	// 强制开启novamap
 
 static bool efi_noinitrd;
 static bool efi_nosoftreserve;

--- a/inc/dragonstub/dragonstub.h
+++ b/inc/dragonstub/dragonstub.h
@@ -469,11 +469,11 @@ union efi_memory_attribute_protocol {
 /**
  * 安装到efi config table的信息
  * 
- * 表示dragonstub加载的内核的地址和大小
+ * 表示dragonstub把内核加载到的地址和大小
 */
 struct dragonstub_payload_efi {
-	u64 payload_addr;
-	u64 payload_size;
+	u64 loaded_addr;
+	u64 size;
 };
 
 #define DRAGONSTUB_EFI_PAYLOAD_EFI_GUID                               \


### PR DESCRIPTION
禁用VAMAP的原因是,退出BootService后,当我们调用Set VirtAddressMap的时候,会修改Systemtable的Configuration Table的值 ,导致内核获取到的config table内容为空.(这应该是一个bug,但我暂时没找到,因此禁用VAMAP临时解决)